### PR TITLE
Added reading rom files feature

### DIFF
--- a/cmd/gomu/gomu.go
+++ b/cmd/gomu/gomu.go
@@ -1,7 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"../../pkg/gba"
+)
 
 func main() {
-	fmt.Println("Hello GoMu")
+	gba.InitializeROM("cartridge/game.GBA")
 }

--- a/pkg/gba/arm7.go
+++ b/pkg/gba/arm7.go
@@ -1,0 +1,187 @@
+package gba
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+)
+
+type registerSet struct {
+	// General Purpose Registers
+	r0  uint32
+	r1  uint32
+	r2  uint32
+	r3  uint32
+	r4  uint32
+	r5  uint32
+	r6  uint32
+	r7  uint32
+	r8  uint32
+	r9  uint32
+	r10 uint32
+	r11 uint32
+	r12 uint32
+	// Stack Pointer - SP
+	r13 uint32
+	// Link Register - LP
+	r14 uint32
+	// Program Counter - PC
+	r15 uint32
+	// Current Program Status Register - CPSR
+	cpsr uint32
+
+	// Banked Registers for Fast Interrupt Request (FIQ) mode
+	r8FIQMode  uint32
+	r9FIQMode  uint32
+	r10FIQMode uint32
+	r11FIQMode uint32
+	r12FIQMode uint32
+	r13FIQMode uint32
+	r14FIQMode uint32
+	// Saved Program Status Register - SPSR
+	spsrFiq uint32
+
+	// Banked Supervisor Calls (SVC) mode registers
+	r13SupervisorMode  uint32
+	r14SupervisorMode  uint32
+	spsrSupervisorMode uint32
+
+	// Banked Abort Mode (ABT) registers
+	r13AbortMode  uint32
+	r14AbortMode  uint32
+	spsrAbortMode uint32
+
+	// Banked Interrupt Mode (IRQ) registers
+	r13InterruptMode  uint32
+	r14InterruptMode  uint32
+	spsrInterruptMode uint32
+
+	// Banked Undefined Mode registers
+	r13UndefinedMode  uint32
+	r14UndefinedMode  uint32
+	spsrUndefinedMode uint32
+}
+
+func (registers *registerSet) reset(usingBIOS bool) {
+	registers.r0, registers.r1, registers.r2, registers.r3, registers.r4, registers.r5 = 0x0, 0x0, 0x0, 0x0, 0x0, 0x0
+	registers.r6, registers.r7, registers.r8, registers.r9, registers.r10 = 0x0, 0x0, 0x0, 0x0, 0x0
+	registers.r11, registers.r12, registers.r13, registers.r14 = 0x0, 0x0, 0x0, 0x0
+
+	registers.r8FIQMode, registers.r9FIQMode, registers.r10FIQMode, registers.r11FIQMode, registers.r12FIQMode, registers.r14FIQMode = 0x0, 0x0, 0x0, 0x0, 0x0, 0x0
+
+	registers.r14SupervisorMode, registers.spsrSupervisorMode = 0x0, 0x0
+	registers.r14AbortMode, registers.spsrAbortMode = 0x0, 0x0
+	registers.r14InterruptMode, registers.spsrInterruptMode = 0x0, 0x0
+	registers.r14UndefinedMode, registers.spsrUndefinedMode = 0x0, 0x0
+
+	// If not booting from the BIOS
+	if !usingBIOS {
+		registers.r13, registers.r13FIQMode, registers.r13AbortMode, registers.r13UndefinedMode = 0x03007F00, 0x03007F00, 0x03007F00, 0x03007F00
+		registers.r15 = 0x8000000
+		registers.r13SupervisorMode = 0x03007FE0
+		registers.r13InterruptMode = 0x03007FA0
+		registers.cpsr = 0x5F
+	} else {
+		registers.r13, registers.r13FIQMode, registers.r13AbortMode, registers.r13UndefinedMode = 0x0, 0x0, 0x0, 0x0
+		registers.r15 = 0x0
+		registers.r13SupervisorMode = 0x0
+		registers.r13InterruptMode = 0x0
+		registers.cpsr = 0xD3
+	}
+
+}
+
+func (registers *registerSet) getRegister(register uint32) uint32 {
+	registerName := fmt.Sprintf("r%d", register)
+	registerValue := reflect.Indirect(reflect.ValueOf(registers)).FieldByName(registerName)
+	// This check is used to avoid "cannot return value obtained from unexported field or method" panic
+	if registerValue.CanInterface() {
+		return registerValue.Interface().(uint32)
+	}
+	return 0x0
+}
+
+func (registers *registerSet) setRegister(register uint32, value uint32) {
+	switch register {
+	case 0:
+		registers.r0 = value
+	case 1:
+		registers.r1 = value
+	case 2:
+		registers.r2 = value
+	case 3:
+		registers.r3 = value
+	case 4:
+		registers.r4 = value
+	case 5:
+		registers.r5 = value
+	case 6:
+		registers.r6 = value
+	case 7:
+		registers.r7 = value
+	case 8:
+		registers.r8 = value
+	case 9:
+		registers.r9 = value
+	case 10:
+		registers.r10 = value
+	case 11:
+		registers.r11 = value
+	case 12:
+		registers.r12 = value
+	case 13:
+		registers.r13 = value
+	case 14:
+		registers.r14 = value
+	case 15:
+		registers.r15 = value
+	default:
+		log.Println("You're are trying to overwrite a non-existent register")
+	}
+}
+
+func branchWithLink(instruction []byte, registers *registerSet) {
+	// First, we correct the byte order of the opcode
+	fixedOInstruction := translateLittleEndianInstruction(instruction)
+
+	// We grab the offset
+	offset := fixedOInstruction & 0xFFFFFF
+
+	// If the offset is negative (24th offset bit is 1), do a complement of 2.
+	if offset>>23&0x1 == 0x1 {
+		offset = -offset
+	}
+
+	// For the opcode, we shift right 24 bits and grab just the first bit
+	opcode := (fixedOInstruction >> 24) & 0x1
+	/// Update the program counter
+	registers.r15 += 8 + 4*offset
+
+	switch opcode {
+	// Branch operation
+	case 0x0:
+	// Branch with link operation
+	case 0x1:
+		registers.r14 = registers.r15 + 4
+	}
+
+}
+
+func branchAndExchange(instruction []byte, registers *registerSet) {
+	fixedInstruction := translateLittleEndianInstruction(instruction)
+
+	sourceRegister := fixedInstruction & 0xF
+	operation := (fixedInstruction >> 4) & 0x1
+
+	actualRegisterValue := registers.getRegister(sourceRegister)
+	registers.r15 = actualRegisterValue
+
+	switch operation {
+	// Branch
+	case 0:
+	// Branch and Exchange
+	case 3:
+		registers.r14 = registers.r15 + 0x4
+	}
+
+}

--- a/pkg/gba/arm7.go
+++ b/pkg/gba/arm7.go
@@ -65,9 +65,10 @@ type registerSet struct {
 func (registers *registerSet) reset(usingBIOS bool) {
 	registers.r0, registers.r1, registers.r2, registers.r3, registers.r4, registers.r5 = 0x0, 0x0, 0x0, 0x0, 0x0, 0x0
 	registers.r6, registers.r7, registers.r8, registers.r9, registers.r10 = 0x0, 0x0, 0x0, 0x0, 0x0
-	registers.r11, registers.r12, registers.r13, registers.r14 = 0x0, 0x0, 0x0, 0x0
+	registers.r11, registers.r12, registers.r14 = 0x0, 0x0, 0x0
 
-	registers.r8FIQMode, registers.r9FIQMode, registers.r10FIQMode, registers.r11FIQMode, registers.r12FIQMode, registers.r14FIQMode = 0x0, 0x0, 0x0, 0x0, 0x0, 0x0
+	registers.r8FIQMode, registers.r9FIQMode, registers.r10FIQMode, registers.r11FIQMode = 0x0, 0x0, 0x0, 0x0
+	registers.r12FIQMode, registers.r14FIQMode = 0x0, 0x0
 
 	registers.r14SupervisorMode, registers.spsrSupervisorMode = 0x0, 0x0
 	registers.r14AbortMode, registers.spsrAbortMode = 0x0, 0x0

--- a/pkg/gba/arm7_test.go
+++ b/pkg/gba/arm7_test.go
@@ -1,0 +1,52 @@
+package gba
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type Arm7TestSuite struct {
+	suite.Suite
+	registers registerSet
+}
+
+func (suite *Arm7TestSuite) SetupTest() {
+	suite.registers.r0 = 0x5
+	suite.registers.r13 = 0x15
+	suite.registers.r15 = 0x20
+	suite.registers.r13SupervisorMode = 0x25
+	suite.registers.r13InterruptMode = 0x30
+	suite.registers.cpsr = 0x35
+}
+
+func TestArm7TestSuite(t *testing.T) {
+	suite.Run(t, new(Arm7TestSuite))
+}
+
+func (suite *Arm7TestSuite) TestRegisterResetWhenNotBootingFromBIOS() {
+	suite.registers.reset(false)
+
+	assert.Equal(suite.T(), uint32(0x0), suite.registers.r0)
+	assert.Equal(suite.T(), uint32(0x03007F00), suite.registers.r13)
+	assert.Equal(suite.T(), uint32(0x8000000), suite.registers.r15)
+	assert.Equal(suite.T(), uint32(0x03007FE0), suite.registers.r13SupervisorMode)
+	assert.Equal(suite.T(), uint32(0x03007FA0), suite.registers.r13InterruptMode)
+	assert.Equal(suite.T(), uint32(0x5F), suite.registers.cpsr)
+}
+
+func (suite *Arm7TestSuite) TestRegisterResetWhenBootingFromBIOS() {
+	suite.registers.reset(true)
+
+	assert.Equal(suite.T(), uint32(0x0), suite.registers.r0)
+	assert.Equal(suite.T(), uint32(0x0), suite.registers.r13)
+	assert.Equal(suite.T(), uint32(0x0), suite.registers.r15)
+	assert.Equal(suite.T(), uint32(0x0), suite.registers.r13SupervisorMode)
+	assert.Equal(suite.T(), uint32(0x0), suite.registers.r13InterruptMode)
+	assert.Equal(suite.T(), uint32(0xD3), suite.registers.cpsr)
+}
+
+func (suite *Arm7TestSuite) TestGetGeneralPurposeRegister() {
+	assert.Equal(suite.T(), uint32(0x5), suite.registers.getRegister(0x0))
+}

--- a/pkg/gba/cartridge.go
+++ b/pkg/gba/cartridge.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-type CartridgeHeader struct {
+type cartridgeHeader struct {
 	/*
 		Space for a single 32bit ARM opcode that redirects to the actual startaddress of the cartridge,
 		this should be usually a "B <start>" instruction.
@@ -99,8 +99,8 @@ func readROMFile(romPath string) []byte {
 	return romBytes
 }
 
-func extractHeaderData(romData []byte) *CartridgeHeader {
-	header := new(CartridgeHeader)
+func extractHeaderData(romData []byte) *cartridgeHeader {
+	header := new(cartridgeHeader)
 
 	header.romEntryPoint = romData[0x000:0x003]
 	header.gameTitle = romData[0x0A0:0x0AB]
@@ -119,7 +119,7 @@ func extractHeaderData(romData []byte) *CartridgeHeader {
 	return header
 }
 
-func logHeaderData(header *CartridgeHeader) {
+func logHeaderData(header *cartridgeHeader) {
 	log.Println("Reading cartridge readers...")
 	log.Println("ROM Entry Point: ", header.romEntryPoint)
 	log.Println("Game Title: ", string(header.gameTitle))

--- a/pkg/gba/cartridge.go
+++ b/pkg/gba/cartridge.go
@@ -1,0 +1,137 @@
+package gba
+
+import (
+	"bufio"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+type CartridgeHeader struct {
+	/*
+		Space for a single 32bit ARM opcode that redirects to the actual startaddress of the cartridge,
+		this should be usually a "B <start>" instruction.
+	*/
+	romEntryPoint []byte
+	/*
+		Contains the Nintendo logo which is displayed during the boot procedure. Cartridge won't work if this data is missing or modified.
+		A copy of the compression data is stored in the BIOS, the GBA will compare this data and lock-up itself if the BIOS data
+		isn't exactly the same as in the cartridge.
+	*/
+	nintendoLogo []byte
+	/*
+		Space for the game title, padded with 00h (if less than 12 chars).
+	*/
+	gameTitle []byte
+	/*
+		The first character (U) is usually "A" or "B", the second/third characters (TT) are usually an
+		abbreviation of the game title and the fourth character indicates destination/language.
+	*/
+	gameCode []byte
+	/*
+		Identifies the (commercial) developer. For example, "01"=Nintendo.
+		This guuy should be treated as binary always, I think.
+	*/
+	makerCode []byte
+	/*
+		Must be 96h (150 dec). Required
+	*/
+	fixedValue byte
+	/*
+		Identifies the required hardware. Should be 00h for current GBA models.
+	*/
+	mainUnitCode byte
+	/*
+		Normally, this entry should be zero
+	*/
+	deviceType byte
+	/*
+		Version number of the game. Usually zero.
+	*/
+	softwareVersion byte
+	/*
+		Header checksum, cartridge won't work if incorrect. Calculate as such:
+		chk=0:for i=0A0h to 0BCh:chk=chk-[i]:next:chk=(chk-19h) and 0FFh
+	*/
+	complementCheck byte
+	/*
+		This entry is used only if the GBA has been booted by using Normal or Multiplay transfer mode.
+		Typically deposit a ARM-32bit "B <start>" branch opcode at this location, which is pointing to your actual initialization procedure.
+	*/
+	ramEntryPoint []byte
+	/*
+		Indicaties the used multiboot transfer mode: 01h -> Joybus mode, 02h -> Normal mode, 03h -> Multiplay mode.
+		Initially zero.
+	*/
+	bootMode byte
+	/*
+		If the GBA has been booted in Normal or Multiplay mode, this byte becomes overwritten by the slave ID number
+		of the local GBA (that'd be always 01h for normal mode). Initially as 00h.
+	*/
+	slaveID byte
+	/*
+		If the GBA has been booted by using Joybus transfer mode, then the entry point is located at this address.
+	*/
+	joybusEntryPoint []byte
+}
+
+func readROMFile(romPath string) []byte {
+	absRomPath, _ := filepath.Abs(romPath)
+
+	log.Println("Loading rom file ...")
+	romFile, err := os.Open(absRomPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	stats, statsErr := romFile.Stat()
+	if statsErr != nil {
+		log.Fatal(statsErr)
+	}
+
+	size := stats.Size()
+	log.Println("ROM with", size/1024, "KB loaded")
+
+	romBytes := make([]byte, size)
+	reader := bufio.NewReader(romFile)
+	_, err = reader.Read(romBytes)
+
+	return romBytes
+}
+
+func extractHeaderData(romData []byte) *CartridgeHeader {
+	header := new(CartridgeHeader)
+
+	header.romEntryPoint = romData[0x000:0x003]
+	header.gameTitle = romData[0x0A0:0x0AB]
+	header.gameCode = romData[0x0AC:0x0AF]
+	header.makerCode = romData[0x0B0:0x0B1]
+	header.fixedValue = romData[0x0B2]
+	header.mainUnitCode = romData[0x0B3]
+	header.deviceType = romData[0x0B4]
+	header.softwareVersion = romData[0x0BC]
+	header.complementCheck = romData[0x0BD]
+	header.ramEntryPoint = romData[0x0C0:0x0C3]
+	header.bootMode = romData[0x0C4]
+	header.slaveID = romData[0x0C5]
+	header.joybusEntryPoint = romData[0x0E0:0x0E3]
+
+	return header
+}
+
+func logHeaderData(header *CartridgeHeader) {
+	log.Println("Reading cartridge readers...")
+	log.Println("ROM Entry Point: ", header.romEntryPoint)
+	log.Println("Game Title: ", string(header.gameTitle))
+	log.Println("Game Code: ", string(header.gameCode))
+	log.Println("Maker Code: ", string(header.makerCode))
+	log.Println("Fixed Value: ", header.fixedValue)
+	log.Println("Main unit code: ", header.mainUnitCode)
+	log.Println("Device type: ", header.deviceType)
+	log.Println("Software version: ", header.softwareVersion)
+	log.Println("Complement Check: ", header.complementCheck)
+	log.Println("RAM Entry Point: ", header.ramEntryPoint)
+	log.Println("Boot mode: ", header.bootMode)
+	log.Println("Slave ID Number: ", header.slaveID)
+	log.Println("Joybus Entry Point: ", header.joybusEntryPoint)
+}

--- a/pkg/gba/cartridge.go
+++ b/pkg/gba/cartridge.go
@@ -9,7 +9,7 @@ import (
 
 type cartridgeHeader struct {
 	/*
-		Space for a single 32bit ARM opcode that redirects to the actual startaddress of the cartridge,
+		Space for a single 32bit ARM opcode that redirects to the actual start address of the cartridge,
 		this should be usually a "B <start>" instruction.
 	*/
 	romEntryPoint []byte
@@ -102,26 +102,26 @@ func readROMFile(romPath string) []byte {
 func extractHeaderData(romData []byte) *cartridgeHeader {
 	header := new(cartridgeHeader)
 
-	header.romEntryPoint = romData[0x000:0x003]
-	header.gameTitle = romData[0x0A0:0x0AB]
-	header.gameCode = romData[0x0AC:0x0AF]
-	header.makerCode = romData[0x0B0:0x0B1]
+	header.romEntryPoint = romData[0x000:0x004]
+	header.gameTitle = romData[0x0A0:0x0AC]
+	header.gameCode = romData[0x0AC:0x0B0]
+	header.makerCode = romData[0x0B0:0x0B2]
 	header.fixedValue = romData[0x0B2]
 	header.mainUnitCode = romData[0x0B3]
 	header.deviceType = romData[0x0B4]
 	header.softwareVersion = romData[0x0BC]
 	header.complementCheck = romData[0x0BD]
-	header.ramEntryPoint = romData[0x0C0:0x0C3]
+	header.ramEntryPoint = romData[0x0C0:0x0C4]
 	header.bootMode = romData[0x0C4]
 	header.slaveID = romData[0x0C5]
-	header.joybusEntryPoint = romData[0x0E0:0x0E3]
+	header.joybusEntryPoint = romData[0x0E0:0x0E4]
 
 	return header
 }
 
 func logHeaderData(header *cartridgeHeader) {
 	log.Println("Reading cartridge readers...")
-	log.Println("ROM Entry Point: ", header.romEntryPoint)
+	log.Printf("ROM Entry Point: %08b\n", header.romEntryPoint)
 	log.Println("Game Title: ", string(header.gameTitle))
 	log.Println("Game Code: ", string(header.gameCode))
 	log.Println("Maker Code: ", string(header.makerCode))
@@ -130,8 +130,8 @@ func logHeaderData(header *cartridgeHeader) {
 	log.Println("Device type: ", header.deviceType)
 	log.Println("Software version: ", header.softwareVersion)
 	log.Println("Complement Check: ", header.complementCheck)
-	log.Println("RAM Entry Point: ", header.ramEntryPoint)
+	log.Printf("RAM Entry Point: %08b\n", header.ramEntryPoint)
 	log.Println("Boot mode: ", header.bootMode)
 	log.Println("Slave ID Number: ", header.slaveID)
-	log.Println("Joybus Entry Point: ", header.joybusEntryPoint)
+	log.Printf("Joybus Entry Point: %08b\n", header.joybusEntryPoint)
 }

--- a/pkg/gba/core.go
+++ b/pkg/gba/core.go
@@ -1,5 +1,6 @@
 package gba
 
+// InitializeROM loads the rom file and extract it's headers
 func InitializeROM(romPath string) {
 	romData := readROMFile(romPath)
 	headers := extractHeaderData(romData[0x000:0x0E3])

--- a/pkg/gba/core.go
+++ b/pkg/gba/core.go
@@ -5,4 +5,7 @@ func InitializeROM(romPath string) {
 	romData := readROMFile(romPath)
 	headers := extractHeaderData(romData[0x000:0x0E3])
 	logHeaderData(headers)
+	registers := new(registerSet)
+	branchWithLink(headers.romEntryPoint, registers)
+	branchAndExchange([]byte{0xE5, 0x0, 0x81, 0xE5}, registers)
 }

--- a/pkg/gba/core.go
+++ b/pkg/gba/core.go
@@ -1,0 +1,7 @@
+package gba
+
+func InitializeROM(romPath string) {
+	romData := readROMFile(romPath)
+	headers := extractHeaderData(romData[0x000:0x0E3])
+	logHeaderData(headers)
+}

--- a/pkg/gba/util.go
+++ b/pkg/gba/util.go
@@ -1,0 +1,7 @@
+package gba
+
+import "encoding/binary"
+
+func translateLittleEndianInstruction(instruction []byte) uint32 {
+	return binary.LittleEndian.Uint32(instruction)
+}


### PR DESCRIPTION
Added to files to envelop the cartridges and core operations, along with file reading and ROM header data extraction. 

Since we must not provide any ROM in the repository, for testing purposes, any `.gba` file can be put in any directory with the `gomu.go` changed to search in the right path.